### PR TITLE
[FEAT]通知の全体的な実装

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -23,21 +23,27 @@ const messaging = firebase.messaging();
 
 // 通知を受けとると push イベントが呼び出される。
 self.addEventListener('push', function (event) {
-  const notificationPromise = self.registration.showNotification(
-    event.messageTitle,
-    {
-      body: event.messageBody,
-      tag: event.messageTag
-    });
+  const data = event.data ? event.data.json() : {};
+
+  console.log('Push event data:', data);
+
+  const notificationTitle = data.data.title || 'デフォルトのタイトル';
+  const notificationOptions = {
+    body: data.data.body || 'デフォルトのメッセージ',
+    tag: data.data.tag || 'default-tag',
+    icon: data.data.icon || '/BirthHiyokoIcon-512.png',
+  };
+
+  const notificationPromise = self.registration.showNotification(notificationTitle, notificationOptions);
   event.waitUntil(notificationPromise);
-}, false)
+});
 
 // WEBアプリがバックグラウンドの場合にはsetBackGroundMessageHandlerが呼び出される。
 messaging.setBackgroundMessageHandler(function (event) {
   return self.registration.showNotification(
     event.messageTitle,
     {
-      body: event.messageBody,
-      tag: event.messageTag
+      body: event.messageBody || 'お知らせが届いています。',
+      tag: event.messageTag || 'これはタグです。',
     });
 });

--- a/src/app/api/notification/route.ts
+++ b/src/app/api/notification/route.ts
@@ -46,8 +46,6 @@ export async function GET() {
     const hundredDaysLater = new Date();
     hundredDaysLater.setDate(today.getDate() + 364);
 
-    let registrationTokens: string[] = [];
-
     const usersSnapshot = await db.collection("users").get();
     let usersData: User[] = usersSnapshot.docs.map((doc) => ({
       id: doc.id,
@@ -105,7 +103,7 @@ export async function GET() {
       }
     }
 
-    return NextResponse.json({ message: "Notifications sent", tokens: registrationTokens });
+    return NextResponse.json({ message: "Notifications sent" });
   } catch (error) {
     console.error("Error fetching user data:", error);
     return NextResponse.json({ error: "Error fetching user data" }, { status: 500 });

--- a/src/app/api/notification/route.ts
+++ b/src/app/api/notification/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { initializeApp, cert } from "firebase-admin/app";
 import { getFirestore } from "firebase-admin/firestore";
 import { getMessaging } from "firebase-admin/messaging";
+import { FirebaseError } from "firebase-admin";
 import { getApps } from "firebase-admin/app";
 require('dotenv').config();
 
@@ -92,11 +93,13 @@ export async function GET() {
           try {
             const response = await messaging.send(message);
             console.log(`Message sent successfully to ${user.nickname}:`, response);
-          } catch (error: any) {
-            if (error.code === 'messaging/registration-token-not-registered') {
+          } catch (error: unknown) {
+            const firebaseError = error as FirebaseError;
+            
+            if (firebaseError.code === 'messaging/registration-token-not-registered') {
               console.error(`Token for ${user.nickname} is invalid or unregistered. Skipping.`);
             } else {
-              console.error(`Failed to send message to ${user.nickname}:`, error);
+              console.error(`Failed to send message to ${user.nickname}:`, firebaseError);
             }
           }
         }

--- a/src/app/api/notification/route.ts
+++ b/src/app/api/notification/route.ts
@@ -5,19 +5,16 @@ import { getMessaging } from "firebase-admin/messaging";
 import { getApps } from "firebase-admin/app";
 require('dotenv').config();
 
-
-// User型の定義
 interface User {
   id: string;
   nickname: string;
   friends?: string[];
   birthMonth?: number;
   birthDay?: number;
-  friendsDetails?: FriendDetail[]; // フレンドの詳細情報の配列
-  token?: string; // ユーザーのトークン
+  friendsDetails?: FriendDetail[];
+  token?: string;
 }
 
-// FriendDetail型の定義
 interface FriendDetail {
   id: string;
   nickname: string;
@@ -25,39 +22,32 @@ interface FriendDetail {
   birthDay?: number;
 }
 
-// Firebase Admin SDKの初期化
-// const serviceAccount = require("/firebaseSecretKey.json");
-// console.log(serviceAccount);
 let firebaseApp = getApps().find(app => app.name === 'notification')
 
 const projectId = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
-console.log('NEXT_PUBLIC_FIREBASE_PROJECT_ID',projectId);
 const clientEmail = process.env.NEXT_PUBLIC_FIREBASE_CLIENT_EMAIL;
-console.log('NEXT_PUBLIC_FIREBASE_CLIENT_EMAIL',clientEmail);
 const privateKey = process.env.NEXT_PUBLIC_PRIVATE_KEY;
-console.log('NEXT_PUBLIC_PRIVATE_KEY',privateKey);
-
 
 if (!firebaseApp) {
-  console.log('initializeApp');
   firebaseApp = initializeApp({
-    // credential: cert(serviceAccount),
     credential: cert({
       projectId,
       clientEmail,
       privateKey,
     }),
-  }, 'notification'); // 新しいアプリを初期化
+  }, 'notification');
 }
 
 const db = getFirestore(firebaseApp);
 
 export async function GET() {
   try {
-    // トークンの配列（友人がいるユーザーのトークンを保持）
+    const today = new Date();
+    const hundredDaysLater = new Date();
+    hundredDaysLater.setDate(today.getDate() + 364);
+
     let registrationTokens: string[] = [];
 
-    // Firestoreから全ユーザー情報を取得
     const usersSnapshot = await db.collection("users").get();
     let usersData: User[] = usersSnapshot.docs.map((doc) => ({
       id: doc.id,
@@ -65,53 +55,57 @@ export async function GET() {
       friends: doc.data().friends || [],
       birthMonth: doc.data().birthMonth,
       birthDay: doc.data().birthDay,
-      token: doc.data().token, // ユーザーのトークンを取得
+      token: doc.data().token,
     }));
 
-    // friendsが存在するユーザーのみをフィルタリング
-    usersData = usersData.filter(user => user.friends && user.friends.length > 0);
+    usersData = usersData.filter(user => user.friends && user.friends.length > 0 && user.token);
 
-    // 各ユーザーのフレンド情報を取得
     for (const user of usersData) {
-      // フレンドのIDからフレンド情報を取得
-      const friendsSnapshot = await db.collection("users")
-        .where('__name__', 'in', user.friends)
-        .get();
-
-      // フレンド情報の抽出
-      user.friendsDetails = friendsSnapshot.docs.map(friendDoc => ({
-        id: friendDoc.id,
-        nickname: friendDoc.data().nickname,
-        birthDay: friendDoc.data().birthDay,
-        birthMonth: friendDoc.data().birthMonth,
-      }));
-
-      // 友人がいるユーザーのトークンをtoken配列に追加
       if (user.token) {
-        registrationTokens.push(user.token);
+        const friendsSnapshot = await db.collection("users")
+          .where('__name__', 'in', user.friends)
+          .get();
+
+        const birthdayFriends = friendsSnapshot.docs.filter(friendDoc => {
+          const friendData = friendDoc.data();
+          const friendBirthdayThisYear = new Date(today.getFullYear(), friendData.birthMonth - 1, friendData.birthDay);
+
+          if (friendBirthdayThisYear >= today && friendBirthdayThisYear <= hundredDaysLater) {
+            return true;
+          }
+
+          const friendBirthdayNextYear = new Date(today.getFullYear() + 1, friendData.birthMonth - 1, friendData.birthDay);
+          return friendBirthdayNextYear >= today && friendBirthdayNextYear <= hundredDaysLater;
+        });
+
+        if (birthdayFriends.length > 0) {
+          const messaging = getMessaging(firebaseApp);
+
+          const message = {
+            data: {
+              title: "友人の誕生日が近いています！",
+              body: `${birthdayFriends.map(friendDoc => friendDoc.data().nickname).join(", ")}の誕生日が近づいています！`,
+              tag: "birthday-notification",
+              icon: `${birthdayFriends[0].data().photoURL}`,
+            },
+            token: user.token,
+          };
+
+          try {
+            const response = await messaging.send(message);
+            console.log(`Message sent successfully to ${user.nickname}:`, response);
+          } catch (error: any) {
+            if (error.code === 'messaging/registration-token-not-registered') {
+              console.error(`Token for ${user.nickname} is invalid or unregistered. Skipping.`);
+            } else {
+              console.error(`Failed to send message to ${user.nickname}:`, error);
+            }
+          }
+        }
       }
     }
-    console.log(registrationTokens);
-    // フラットにして重複を排除
-    registrationTokens = [...new Set(registrationTokens.flat())];
 
-    if (registrationTokens.length > 0) {
-      const messaging = getMessaging(firebaseApp);
-      const message = {
-        notification: {
-          title: 'お知らせ',
-          body: 'あなたの友人の誕生日が近づいています！',
-        },
-        tokens: registrationTokens,
-      };
-
-      // メッセージの送信
-      const response = await messaging.sendEachForMulticast(message);
-      console.log(response.successCount + ' messages were sent successfully');
-    }
-
-    // データをレスポンスとして返す
-    return NextResponse.json({ users: usersData, tokens: registrationTokens });
+    return NextResponse.json({ message: "Notifications sent", tokens: registrationTokens });
   } catch (error) {
     console.error("Error fetching user data:", error);
     return NextResponse.json({ error: "Error fetching user data" }, { status: 500 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import CardTitle from "./components/CardTitle";
 import Image from "next/image";
 import WideDecisionButton from "./components/WideDecisionButton";
 import { useRouter } from "next/navigation";
+import { requestPermission } from '../lib/firebase';
 
 export default function Home() {
   const router = useRouter();
@@ -27,6 +28,7 @@ export default function Home() {
 
   useEffect(() => {
     if (user) {
+      requestPermission();
       router.push('/birth-tree');
     } else{
       router.push('/');

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,6 +1,7 @@
 import { initializeApp, getApps } from "firebase/app";
-import { getFirestore } from "firebase/firestore";
+import { doc, getDoc, updateDoc, arrayUnion, getFirestore } from "firebase/firestore";
 import { getAuth } from "firebase/auth";
+import { useAuth } from '@/context/auth';
 import { getMessaging, getToken } from "firebase/messaging";
 import { getStorage } from "firebase/storage";
 
@@ -32,6 +33,19 @@ export function requestPermission() {
       }).then((currentToken) => {
         if (currentToken) {
           console.log("current token for client: ", currentToken);
+          const user = auth.currentUser;
+          if (user) {
+            const userDocRef = doc(db, "users", user.uid);
+            updateDoc(userDocRef, { token: currentToken })
+              .then(() => {
+                console.log("Token successfully saved to Firestore.");
+              })
+              .catch((error) => {
+                console.error("Error saving token to Firestore: ", error);
+              });
+          } else {
+            console.error("No user is logged in.");
+          }
         } else {
           console.error(
             "No registration token available. Request permission to generate one."

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,7 +1,6 @@
 import { initializeApp, getApps } from "firebase/app";
-import { doc, getDoc, updateDoc, arrayUnion, getFirestore } from "firebase/firestore";
+import { doc, updateDoc, getFirestore } from "firebase/firestore";
 import { getAuth } from "firebase/auth";
-import { useAuth } from '@/context/auth';
 import { getMessaging, getToken } from "firebase/messaging";
 import { getStorage } from "firebase/storage";
 


### PR DESCRIPTION
## 今回の要件

- ログインしているユーザーに通知の許可を求める
- 364日以内に誕生日の友達がいる場合に通知
- 通知内容は「友達名前を羅列」 + 「の誕生日が近づいています！」+ 先頭の人の写真

## 今回の実装で行っていないこと

- 通知の定期実行
- 友達の名前のソート
- 誕生日が〇〇以内の友人絞り込み(現在は364日以内)
- 当日の友達がいる場合の通知内容の変更

## テストの仕方

### 1.使用ブラウザの通知を許可する

> 以下の部分が無効になっていないかを確認

<img width="710" alt="image" src="https://github.com/user-attachments/assets/0f90b212-d29a-406a-8d0c-9475a2ae2bc9">


### 2.ローカルホストを立てる

> ブランチは`feat/register-token`

### 3.初期ユーザーと同じ条件に戻す

- [ ] URLの左のボタンを押して**権限をリセット**
- [ ] ログアウトする(ログアウトボタンは`http://localhost:3000/debug`の下の方にちっちゃくあります)

### 4.実際のユーザーと同じ動作を確認

1. `http://localhost:3000/`を入力
2. ログインする
3. 通知が求められるはずなので`許可する`

### 5.通知を自分で送る

- 違うタブで`http://localhost:3000/api/notification`を入力してEnter

### 6.通知が来るはず！！！！！

# 来なかったら多分太田のせいなのですぐ言ってください